### PR TITLE
Update Asciicast because the current is expired

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -125,7 +125,7 @@ type: index
       <h2>Asciicast</h2>
 
       <p>
-        <script type="text/javascript" src="https://asciinema.org/a/45rplimr59i0pdg9tq6nkm3at.js" id="asciicast-45rplimr59i0pdg9tq6nkm3at" async></script>
+        <script id="asciicast-548385" src="https://asciinema.org/a/548385.js" async></script>
       </p>
 
       <div>Try <code>rib all</code> to enable almost all built-in plugins for above example.</div>


### PR DESCRIPTION
Update Asciicast to the one I uploaded from:

https://github.com/godfat/rib/blob/master/asciicast.json

View it at: https://asciinema.org/a/548385

This is to resolve https://github.com/godfat/rib/issues/25

Feel free to upload another one, or upload yourself so you have control on the cast on the other hand.